### PR TITLE
Refetch new set of articles when user is coming near the page end

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -182,7 +182,7 @@ const Home = () => {
                 </div>
               ) : (
                 // If user has viewed all articles
-                <div className="bg-[#ecd9cb] flex items-center justify-center p-10">
+                <div className="bg-[#ecd9cb] flex items-center justify-center p-6">
                   You have viewed all articles! 🎉
                 </div>
               )
@@ -192,7 +192,7 @@ const Home = () => {
                 <div ref={loadMoreRef}></div>
                 <div>
                   {articlesData.length > 0 && (
-                    <div className="bg-white flex items-center justify-center text-sm lg:text-base p-10">
+                    <div className="bg-white flex items-center justify-center text-sm lg:text-base p-6">
                       Fetching more articles...
                     </div>
                   )}


### PR DESCRIPTION
Added optimization to prevent flickering while setting a newly fetched set of articles by using a custom hook that listens to the scroll stop event and then updates the state with the new set of articles. This is mainly done to prevent flickering that occurs because of the combination of scroll snap CSS utility and fetching the next set of data in infinite scroll. What happens is that whenever a new set of data is fetched and the state is updated, there is flickering that occurs while setting the new state. This occurs only when the scroll snap CSS utility is used.